### PR TITLE
Add binding for aug_print and aug_srun

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@ This library is a low-level binding to the C API of Augeas, with a few abstracti
 ## TODO
 
 * Consider allowing non-UTF-8 strings for paths and values.
-* Consider adding missing bindings if it makes sense:
-  * `aug_print`
+* Consider adding missing bindings for the following functions:
   * `aug_to_xml`
-  * `aug_srun`
 * Allow building with older versions of Augeas (currently, it requires 1.13 or later).
 * [Add augeas to docs.rs build environment](https://forge.rust-lang.org/docs-rs/add-dependencies.html) to allow building the docs.

--- a/raugeas/src/error.rs
+++ b/raugeas/src/error.rs
@@ -2,10 +2,10 @@
 
 use raugeas_sys::*;
 use std::ffi::NulError;
-use std::fmt;
+use std::{fmt, io};
 
 /// Represents possible errors that can occur.
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum Error {
     /// Augeas error
@@ -14,6 +14,8 @@ pub enum Error {
     Tree(Box<TreeError>),
     /// Unexpected nul character
     Nul(NulError),
+    /// I/O error
+    IO(io::Error),
 }
 
 impl fmt::Display for Error {
@@ -22,6 +24,7 @@ impl fmt::Display for Error {
             Error::Augeas(ref err) => err.fmt(f),
             Error::Nul(ref err) => err.fmt(f),
             Error::Tree(ref err) => err.fmt(f),
+            Error::IO(ref err) => err.fmt(f),
         }
     }
 }
@@ -98,6 +101,12 @@ impl From<AugeasError> for Error {
 impl From<TreeError> for Error {
     fn from(err: TreeError) -> Error {
         Error::Tree(Box::new(err))
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
+        Error::IO(err)
     }
 }
 


### PR DESCRIPTION
Instead of using a file, return a `String` for simpler usage.

Uses memfd_create for now, which requires a Linux kernel >= 3.17.